### PR TITLE
Add gesture area for opening menus

### DIFF
--- a/css/basic.css
+++ b/css/basic.css
@@ -1,5 +1,8 @@
+#widthWrapper, #colorPickerContainer {
+    display: none;
+}
 #basic{
-
+    display: none;
     position: absolute;
     top: 0; left: 0;
     width: 370px; height: 100%;

--- a/css/basic.css
+++ b/css/basic.css
@@ -2,15 +2,20 @@
     display: none;
 }
 #basic{
+    background-color: #FFF;
     display: none;
     position: absolute;
     top: 0; left: 10%;
     width: 370px; height: 100%;
     padding: 0; margin: 0;
-    border: 2px solid black;
+    border-right: 2px solid black;
     z-index: 10;
 }
-
+#basic #logo {
+    position: absolute;
+    top: 15px;
+    left: 75px;
+}
 #basic #tools img{
     position: absolute;
     width: 50px;

--- a/css/basic.css
+++ b/css/basic.css
@@ -4,7 +4,7 @@
 #basic{
     display: none;
     position: absolute;
-    top: 0; left: 0;
+    top: 0; left: 10%;
     width: 370px; height: 100%;
     padding: 0; margin: 0;
     border: 2px solid black;

--- a/css/index.css
+++ b/css/index.css
@@ -1,0 +1,7 @@
+div#gestureArea {
+    position: absolute;
+    top: 0; left: 0; 
+    width: 325px; height: 100%;
+    background-color: blue;
+    opacity: 50%;
+}

--- a/css/main.css
+++ b/css/main.css
@@ -1,8 +1,3 @@
-img#logo{
-    position: absolute;
-    top: 15;
-    left: 15;
-}
 div#canvasWrapper, canvas#paint{
     position: absolute;
     top: 0;
@@ -38,4 +33,6 @@ div#gestureArea {
     width: 10%; height: 100%;
     background-color: #88C3FF;
     opacity: 50%;
+    box-sizing: border-box;
+    border-right: 2px solid black;
 }

--- a/css/main.css
+++ b/css/main.css
@@ -1,3 +1,6 @@
+body {
+    overflow: hidden;
+}
 div#canvasWrapper, canvas#paint{
     position: absolute;
     top: 0;

--- a/css/main.css
+++ b/css/main.css
@@ -29,3 +29,13 @@ img {
     -ms-user-select: none; /* IE10+/Edge */
     user-select: none; /* Standard */
 }
+
+
+div#gestureArea {
+    z-index: 1;
+    position: absolute;
+    top: 0; left: 0; 
+    width: 325px; height: 100%;
+    background-color: blue;
+    opacity: 50%;
+}

--- a/css/main.css
+++ b/css/main.css
@@ -35,7 +35,7 @@ div#gestureArea {
     z-index: 1;
     position: absolute;
     top: 0; left: 0; 
-    width: 325px; height: 100%;
-    background-color: blue;
+    width: 10%; height: 100%;
+    background-color: #88C3FF;
     opacity: 50%;
 }

--- a/css/radial.css
+++ b/css/radial.css
@@ -14,6 +14,8 @@
 
 #radial #tools img {
     position: absolute;
+    background-color: #EEEEEE90;
+    border-radius: 30%;
 }
 
 #background {

--- a/js/basic.js
+++ b/js/basic.js
@@ -1,15 +1,16 @@
 let menuOpen=true;
-function openMenu(){
-
+function openMenu(){ 
+    $("#basic, #widthWrapper, #colorPickerContainer").css({display: "block"});
 }
 
 function closeMenu(){
-
+    $("#basic, #widthWrapper, #colorPickerContainer").css({display: "none"});
 }
 
 function initBasicMenu(){
-    openColorPickerMenu({top: 220, left: 65});
-    openLineWidthMenu({top: 500, left: 5});
+    let gestureWidth = $("#gestureArea").width();
+    openColorPickerMenu({top: 220, left: 65 + gestureWidth});
+    openLineWidthMenu({top: 500, left: 5 + gestureWidth});
 }
 
 $(document).ready(initBasicMenu);

--- a/js/dial.js
+++ b/js/dial.js
@@ -17,8 +17,6 @@ function initMenu(){
     setMenuAttributes();
     setToolPositions();
     setToolAttributes();
-
-    $("#dial > img").on('mousedown', canvasMouseDown);
 }
 
 function openMenu(center){

--- a/js/dial.js
+++ b/js/dial.js
@@ -21,7 +21,7 @@ function initMenu(){
 
 function openMenu(center){
     let wDiff = window.innerWidth - (center.x + fullRadius);
-    let wZero = center.x - fullRadius;
+    let wZero = (center.x - fullRadius) - $("#gestureArea").width()
     if(wDiff < 0) center.x += wDiff;
     else if(wZero < 0) center.x -= wZero;
 

--- a/js/main.js
+++ b/js/main.js
@@ -1,4 +1,16 @@
 $(document).ready(function(){
     $('img').on('dragstart', function(event) { event.preventDefault(); });
     
+    $("div#gestureArea").on("mousedown touchstart", handleGestureTouch);
+
+    function handleGestureTouch(event){
+        let center;
+        if(lines.length > 0) {
+            let points = lines[lines.length - 1].points;
+            center = points[points.length - 1];
+        } else {
+            center = {x: (window.innerWidth / 2) + $(this).width(), y: window.innerHeight / 2}
+        }
+        openMenu(center);
+    }
 });

--- a/js/main.js
+++ b/js/main.js
@@ -1,3 +1,4 @@
 $(document).ready(function(){
     $('img').on('dragstart', function(event) { event.preventDefault(); });
+    
 });

--- a/js/paint.functions.js
+++ b/js/paint.functions.js
@@ -86,7 +86,7 @@ function resetPainting(isUndo=false){
     //Clear the canvas itself.
     ctx.clearRect(0, 0, canvas.width, canvas.height);
     //Put the logo back on the canvas
-    addLogoToCanvas();
+    //addLogoToCanvas();
 }
 
 //Delete the last line drawn to the painting

--- a/js/paint.js
+++ b/js/paint.js
@@ -10,7 +10,7 @@ function Paint_onLoad(){
     ctx = canvas.getContext("2d");
     Paint_onResize();
 
-    $("img#logo").on("load", addLogoToCanvas);
+    //$("img#logo").on("load", addLogoToCanvas);
     renderInterval = setInterval(render, 15);
 }
 

--- a/js/paint.js
+++ b/js/paint.js
@@ -16,7 +16,7 @@ function Paint_onLoad(){
 
 function addLogoToCanvas(){
     let img = document.getElementById("logo");
-    ctx.drawImage(img, $("#gestureArea").width() + 15, 15);
+    ctx.drawImage(img, window.innerWidth*.15 + 15, 15);
     $("img#logo").css({display: 'none'})
 }
 

--- a/js/paint.js
+++ b/js/paint.js
@@ -1,6 +1,6 @@
 //Made with the good faith of W3Schools;
 //https://www.w3schools.com/tags/ref_canvas.asp
-let MIN_PEN_WIDTH = 2, PEN_WIDTH_RANGE = 60;
+let MIN_PEN_WIDTH = 2, PEN_WIDTH_RANGE = 80;
 let canvas, ctx, canvasColor = "#FFFFFF", lineColor="#1E4D2B", 
     lineWidth = MIN_PEN_WIDTH, lines = [];
 let isErasing = false;

--- a/js/paint.js
+++ b/js/paint.js
@@ -16,7 +16,7 @@ function Paint_onLoad(){
 
 function addLogoToCanvas(){
     let img = document.getElementById("logo");
-    ctx.drawImage(img, 15, 15);
+    ctx.drawImage(img, $("#gestureArea").width() + 15, 15);
     $("img#logo").css({display: 'none'})
 }
 

--- a/js/radial.js
+++ b/js/radial.js
@@ -20,7 +20,7 @@ function openMenu(center){
     if(menuOpen) closeSubMenus();
  
     let wDiff = window.innerWidth - (center.x + fullRadius);
-    let wZero = center.x - fullRadius;
+    let wZero =   (center.x - fullRadius) - $("#gestureArea").width()
     if(wDiff < 0) center.x += wDiff;
     else if(wZero < 0) center.x -= wZero;
 

--- a/js/radial.js
+++ b/js/radial.js
@@ -72,7 +72,7 @@ function setToolPositions(){
             top: pos.y,
             left: pos.x,
             width: 2 * toolRadius,
-            height: 2 *toolRadius
+            height: 2 * toolRadius
         });  
     });
 }

--- a/js/touch.js
+++ b/js/touch.js
@@ -59,5 +59,18 @@ $(document).ready(function(){
             finishLine(pos, touch.identifier);    
         }        
     }
+
+    $("div#gestureArea").on("touchstart", handleGestureTouch);
+
+    function handleGestureTouch(event){
+        let center;
+        if(lines.length > 0) {
+            let points = lines[lines.length - 1].points;
+            center = points[points.length - 1];
+        } else {
+            center = {x: (window.innerWidth / 2) + $(this).width(), y: window.innerHeight / 2}
+        }
+        openMenu(center);
+    }
 });
 

--- a/js/touch.js
+++ b/js/touch.js
@@ -59,18 +59,5 @@ $(document).ready(function(){
             finishLine(pos, touch.identifier);    
         }        
     }
-
-    $("div#gestureArea").on("mousedown touchstart", handleGestureTouch);
-
-    function handleGestureTouch(event){
-        let center;
-        if(lines.length > 0) {
-            let points = lines[lines.length - 1].points;
-            center = points[points.length - 1];
-        } else {
-            center = {x: (window.innerWidth / 2) + $(this).width(), y: window.innerHeight / 2}
-        }
-        openMenu(center);
-    }
 });
 

--- a/js/touch.js
+++ b/js/touch.js
@@ -60,7 +60,7 @@ $(document).ready(function(){
         }        
     }
 
-    $("div#gestureArea").on("touchstart", handleGestureTouch);
+    $("div#gestureArea").on("mousedown touchstart", handleGestureTouch);
 
     function handleGestureTouch(event){
         let center;

--- a/views/basicmenu.pug
+++ b/views/basicmenu.pug
@@ -5,6 +5,7 @@ input(type = 'file', id = 'imgUpload', name = 'backgroundImage' style = 'display
 div(id='background')
 
 div#basic
+    img#logo(src="../images/logo.jpg")
     div#tools
         img#undo(src="../images/undo.png")
         img#trash(src="../images/trash.png")

--- a/views/index.pug
+++ b/views/index.pug
@@ -3,6 +3,7 @@ html
         //- Add to head.pug if you need to add something here.
         include head.pug 
     body
+        div#gestureArea
         img#logo(src="../images/logo.jpg")
         div#sliderContainer
             label.switch(for="touchToggle")

--- a/views/index.pug
+++ b/views/index.pug
@@ -4,7 +4,6 @@ html
         include head.pug 
     body
         div#gestureArea
-        img#logo(src="../images/logo.jpg")
         div#sliderContainer
             label.switch(for="touchToggle")
                 input#touchToggle(type="checkbox" checked=touch)


### PR DESCRIPTION
Adds an area on the left side of the screen that activates the menus

* Currently it is set up to open the basic menu right next to the gesture area
* Opens radial and dial menus at the end of the last line drawn, or the center of the canvas when no lines are present.

closes #56 